### PR TITLE
Add ad banner to the main screen

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,9 +25,14 @@ def init_db():
             )
         ''')
 
+def get_ad_content():
+    # Placeholder function to return ad content
+    return "Ad content goes here"
+
 @app.route('/')
 def home():
-    return render_template('create_event.html')
+    ad_content = get_ad_content()
+    return render_template('create_event.html', ad_content=ad_content)
 
 @app.route('/create', methods=['POST'])
 def create_event():

--- a/templates/create_event.html
+++ b/templates/create_event.html
@@ -33,6 +33,9 @@ Rudolph"></textarea>
                     <button type="submit" class="btn btn-success btn-lg" id="submit-btn">Create Event</button>
                 </div>
             </form>
+            <div class="ad-placeholder">
+                <!-- Google ad script should be placed here -->
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Related to #13

Add a placeholder for Google ads under the names list on the main screen.

* Modify `templates/create_event.html` to include a `div` element with class `ad-placeholder` below the participants' list and add a comment indicating where the Google ad script should be placed.
* Add a placeholder function `get_ad_content` in `app.py` to return ad content.
* Modify the `home` route in `app.py` to pass ad content to the template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Shmarkus/secret_santa/pull/14?shareId=11a5ab2a-b06e-469e-878e-2df3f1ee8b34).